### PR TITLE
Add salt.repo file for new packages.broadcom.com location; add devcontainer for GitHub Workspaces integration

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,35 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+	"name": "Salt Install Guide",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/python:0-3.11-bullseye",
+	"features": {
+		"ghcr.io/devcontainers-contrib/features/pre-commit:2": {
+			"version": "latest"
+		},
+		"ghcr.io/devcontainers-contrib/features/nox:2": {
+			"version": "latest"
+		}
+	},
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "pip3 install -U pip setuptools"
+	"postCreateCommand": "echo \"alias serve='python -m http.server -d /workspaces/salt-install-guide/docs/_build/html'\" >> ~/.bashrc && sudo apt update && sudo apt install vim -y && sudo rm -rf /var/lib/apt/lists/*"
+
+	// There is also a postStartCommand that executes every time the container starts.
+	// The parameters behave exactly like postCreateCommand, but the commands execute on start rather than create.
+	// "postStartCommand": "alias serve='python -m http.server -d /workspaces/salt-install-guide/docs/_build/html' > ~/.bashrc"
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Salt Install Guide",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/python:0-3.11-bullseye",
+	"image": "mcr.microsoft.com/devcontainers/python:0-3.10-bullseye",
 	"features": {
 		"ghcr.io/devcontainers-contrib/features/pre-commit:2": {
 			"version": "latest"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -141,7 +141,6 @@ extensions = [
     "sphinx.ext.todo",
     "sphinx-prompt",  # Required by sphinx_substitution_extensions
     "sphinx_inline_tabs",
-    # "sphinx_multiversion", # To ensure publishing of mulitple, versioned sites
     "sphinx_substitution_extensions",
 ]
 # Render TODO directives

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,12 +1,12 @@
 # If using version selector, use
 # Temporary Furo theme target for versioning
-# furo>=2022.6.21
-Sphinx-Substitution-Extensions>=2022.2.16
+# furo==2022.6.21
+Sphinx-Substitution-Extensions==2022.02.16
 requests>=2.31.0
 salt-furo-versioner @ git+https://github.com/ScriptAutomate/salt-furo-versioner@excelsior
-sphinx-copybutton>=0.5.0
-sphinx-design
-sphinx-inline-tabs>=2022.1.2b11
-sphinx-prompt
-sphinx-tabs>=3.4.1
-sphinx>=5.3.0
+sphinx-copybutton==0.5.2
+sphinx-design==0.5.0
+sphinx-inline-tabs==2023.4.21
+sphinx-prompt==1.5.0
+sphinx-tabs==3.4.7
+sphinx==5.3.0

--- a/salt.repo
+++ b/salt.repo
@@ -1,0 +1,31 @@
+[salt-repo-3006-lts]
+name=Salt Repo for Salt v3006 LTS
+baseurl=https://packages.broadcom.com/artifactory/saltproject-rpm/
+skip_if_unavailable=True
+priority=10
+enabled=1
+enabled_metadata=1
+gpgcheck=1
+exclude=*3007* *3008* *3009* *3010*
+gpgkey=https://packages.broadcom.com/artifactory/api/security/keypair/SaltProjectKey/public
+
+[salt-repo-3007-sts]
+name=Salt Repo for Salt v3007 STS
+baseurl=https://packages.broadcom.com/artifactory/saltproject-rpm/
+skip_if_unavailable=True
+priority=10
+enabled=0
+enabled_metadata=1
+gpgcheck=1
+exclude=*3006* *3008* *3009* *3010*
+gpgkey=https://packages.broadcom.com/artifactory/api/security/keypair/SaltProjectKey/public
+
+[salt-repo-latest]
+name=Salt Repo for Salt LATEST release
+baseurl=https://packages.broadcom.com/artifactory/saltproject-rpm/
+skip_if_unavailable=True
+priority=10
+enabled=0
+enabled_metadata=1
+gpgcheck=1
+gpgkey=https://packages.broadcom.com/artifactory/api/security/keypair/SaltProjectKey/public


### PR DESCRIPTION
- Add salt.repo file for new packages.broadcom.com location
- Add devcontainer for GitHub Workspaces integration
- Fix requirements to ensure successful build, as builds were failing with non-restrictive `requirements.txt`