### PR TITLE
Update naming of salt-archive-keyring for Debian standards, and add minor version locking for rpm-based distros

### DIFF
--- a/docs/topics/install-by-operating-system/linux-deb.rst
+++ b/docs/topics/install-by-operating-system/linux-deb.rst
@@ -21,7 +21,7 @@ Install Salt DEBs
        # Ensure keyrings dir exists
        mkdir -p /etc/apt/keyrings
        # Download public key
-       curl -fsSL https://packages.broadcom.com/artifactory/api/security/keypair/SaltProjectKey/public | sudo tee /etc/apt/keyrings/salt-archive-keyring-2023.pgp
+       curl -fsSL https://packages.broadcom.com/artifactory/api/security/keypair/SaltProjectKey/public | sudo tee /etc/apt/keyrings/salt-archive-keyring.pgp
        # Create apt repo target configuration
        curl -fsSL https://github.com/saltstack/salt-install-guide/releases/latest/download/salt.sources | sudo tee /etc/apt/sources.list.d/salt.sources
 

--- a/docs/topics/install-by-operating-system/linux-deb.rst
+++ b/docs/topics/install-by-operating-system/linux-deb.rst
@@ -5,7 +5,7 @@ Linux (DEB)
 ===========
 
 These instructions explain how to install Salt rpms on operating systems that
-are Debian-like (using `apt-get` install methods).
+are Debian-like (using ``apt-get`` install methods).
 
 For a list of supported and tested operating systems, for running Salt,
 see :ref:`salt-supported-operating-systems`.

--- a/docs/topics/install-by-operating-system/linux-rpm.rst
+++ b/docs/topics/install-by-operating-system/linux-rpm.rst
@@ -5,7 +5,7 @@ Linux (RPM)
 ===========
 
 These instructions explain how to install Salt rpms on operating systems that
-are RHEL-like (using `dnf` install methods).
+are RHEL-like (using ``dnf`` install methods).
 
 For a list of supported and tested operating systems, for running Salt,
 see :ref:`salt-supported-operating-systems`.
@@ -30,7 +30,7 @@ Install Salt RPMs
        downloads classic packages of older versions of Salt instead of the
        onedir packages.
 
-       During depsolving, when choosing the best provider among several, `yum`
+       During depsolving, when choosing the best provider among several, ``dnf``
        respects the priority of each provider's repository. The value is an
        integer from 1 to 99, with 1 being the most preferred repository and 99
        the least preferred. By default all repositories have the priority of 80.
@@ -69,6 +69,22 @@ Install Salt RPMs
                     sudo dnf install salt-cloud-3006.9
                     sudo dnf install salt-api-3006.9
 
+            ``dnf versionlock`` can be used to pin to minor versions, if wanting to be
+            excluded during ``dnf upgrade`` runs on a system.
+
+            .. code-block:: bash
+
+                    sudo dnf install 'dnf-command(versionlock)'
+
+            .. code-block:: bash
+
+                    sudo dnf versionlock add salt
+                    sudo dnf versionlock add salt-master
+                    sudo dnf versionlock add salt-minion
+                    sudo dnf versionlock add salt-ssh
+                    sudo dnf versionlock add salt-syndic
+                    sudo dnf versionlock add salt-cloud
+                    sudo dnf versionlock add salt-api
 
        .. tab-item:: 3007 STS
 
@@ -108,6 +124,22 @@ Install Salt RPMs
                     sudo dnf install salt-cloud-3007.1
                     sudo dnf install salt-api-3007.1
 
+            ``dnf versionlock`` can be used to pin to minor versions, if wanting to be
+            excluded during ``dnf upgrade`` runs on a system.
+
+            .. code-block:: bash
+
+                    sudo dnf install 'dnf-command(versionlock)'
+
+            .. code-block:: bash
+
+                    sudo dnf versionlock add salt
+                    sudo dnf versionlock add salt-master
+                    sudo dnf versionlock add salt-minion
+                    sudo dnf versionlock add salt-ssh
+                    sudo dnf versionlock add salt-syndic
+                    sudo dnf versionlock add salt-cloud
+                    sudo dnf versionlock add salt-api
 
        .. tab-item:: LATEST Available
 
@@ -146,6 +178,23 @@ Install Salt RPMs
                     sudo dnf install salt-syndic-3007.1
                     sudo dnf install salt-cloud-3007.1
                     sudo dnf install salt-api-3007.1
+
+            ``dnf versionlock`` can be used to pin to minor versions, if wanting to be
+            excluded during ``dnf upgrade`` runs on a system.
+
+            .. code-block:: bash
+
+                    sudo dnf install 'dnf-command(versionlock)'
+
+            .. code-block:: bash
+
+                    sudo dnf versionlock add salt
+                    sudo dnf versionlock add salt-master
+                    sudo dnf versionlock add salt-minion
+                    sudo dnf versionlock add salt-ssh
+                    sudo dnf versionlock add salt-syndic
+                    sudo dnf versionlock add salt-cloud
+                    sudo dnf versionlock add salt-api
 
 #. Enable and start the Salt services:
 

--- a/salt.sources
+++ b/salt.sources
@@ -9,6 +9,6 @@ Description: Salt has many possible uses, including configuration management.
 Enabled: yes
 Types: deb
 URIs: https://packages.broadcom.com/artifactory/saltproject-deb
-Signed-By: /etc/apt/keyrings/salt-archive-keyring-2023.pgp
+Signed-By: /etc/apt/keyrings/salt-archive-keyring.pgp
 Suites: stable
 Components: main


### PR DESCRIPTION
- Add minor version locking for rpm-based distros with `dnf versionlock`
- Fix https://github.com/saltstack/salt/issues/64144