### PR TITLE
add linux-rpm install for zypper

### DIFF
--- a/docs/topics/install-by-operating-system/linux-rpm.rst
+++ b/docs/topics/install-by-operating-system/linux-rpm.rst
@@ -20,9 +20,21 @@ Install Salt RPMs
 
 #. Run the following command to install the Salt Project repository:
 
-   .. code-block:: bash
+   .. tab-set::
 
-       curl -fsSL https://github.com/saltstack/salt-install-guide/releases/latest/download/salt.repo | sudo tee /etc/yum.repos.d/salt.repo
+       .. tab-item:: DNF
+
+           .. code-block:: bash
+
+               curl -fsSL https://github.com/saltstack/salt-install-guide/releases/latest/download/salt.repo | sudo tee /etc/yum.repos.d/salt.repo
+
+
+       .. tab-item:: Zypper
+
+           .. code-block:: bash
+
+               curl -fsSL https://github.com/saltstack/salt-install-guide/releases/latest/download/salt-zypper.repo | sudo tee /etc/zypp/repos.d/salt.repo
+
 
    .. Note::
        Because of the presence of classic packages of Salt in EPEL, it's
@@ -38,163 +50,340 @@ Install Salt RPMs
        EPEL was treating the Salt repository as 99. To resolve this issue, Salt
        has changed its priority level to 10 for RHEL 8 and 9.
 
-#. Run ``sudo dnf clean expire-cache`` to clear the repository metadata.
+#. Run the following command to  clear the repository metadata.
+
+   .. tab-set::
+
+       .. tab-item:: DNF
+
+           .. code-block:: bash
+
+               sudo dnf clean expire-cache
+
+
+       .. tab-item:: Zypper
+
+           .. code-block:: bash
+
+               sudo zypper clean
+
+
 
 #. Install the salt-minion, salt-master, or other Salt components:
 
    .. tab-set::
 
-       .. tab-item:: 3006 LTS
+       .. tab-item:: DNF
 
-            Available installs:
+           .. tab-set::
 
-            .. code-block:: bash
+               .. tab-item:: 3006 LTS
 
-                    sudo dnf install salt-master
-                    sudo dnf install salt-minion
-                    sudo dnf install salt-ssh
-                    sudo dnf install salt-syndic
-                    sudo dnf install salt-cloud
-                    sudo dnf install salt-api
+                    Available installs:
 
-            If wanting to install by a target point release, append the specific Salt
-            full release version. For example:
+                    .. code-block:: bash
 
-            .. code-block:: bash
+                            sudo dnf install salt-master
+                            sudo dnf install salt-minion
+                            sudo dnf install salt-ssh
+                            sudo dnf install salt-syndic
+                            sudo dnf install salt-cloud
+                            sudo dnf install salt-api
 
-                    sudo dnf install salt-master-3006.9
-                    sudo dnf install salt-minion-3006.9
-                    sudo dnf install salt-ssh-3006.9
-                    sudo dnf install salt-syndic-3006.9
-                    sudo dnf install salt-cloud-3006.9
-                    sudo dnf install salt-api-3006.9
+                    If wanting to install by a target point release, append the specific Salt
+                    full release version. For example:
 
-            ``dnf versionlock`` can be used to pin to minor versions, if wanting to be
-            excluded during ``dnf upgrade`` runs on a system.
+                    .. code-block:: bash
 
-            .. code-block:: bash
+                            sudo dnf install salt-master-3006.9
+                            sudo dnf install salt-minion-3006.9
+                            sudo dnf install salt-ssh-3006.9
+                            sudo dnf install salt-syndic-3006.9
+                            sudo dnf install salt-cloud-3006.9
+                            sudo dnf install salt-api-3006.9
 
-                    sudo dnf install 'dnf-command(versionlock)'
+                    ``dnf versionlock`` can be used to pin to minor versions, if wanting to be
+                    excluded during ``dnf upgrade`` runs on a system.
 
-            .. code-block:: bash
+                    .. code-block:: bash
 
-                    sudo dnf versionlock add salt
-                    sudo dnf versionlock add salt-master
-                    sudo dnf versionlock add salt-minion
-                    sudo dnf versionlock add salt-ssh
-                    sudo dnf versionlock add salt-syndic
-                    sudo dnf versionlock add salt-cloud
-                    sudo dnf versionlock add salt-api
+                            sudo dnf install 'dnf-command(versionlock)'
 
-       .. tab-item:: 3007 STS
+                    .. code-block:: bash
 
-            .. warning:: STS not recommended for Production
+                            sudo dnf versionlock add salt
+                            sudo dnf versionlock add salt-master
+                            sudo dnf versionlock add salt-minion
+                            sudo dnf versionlock add salt-ssh
+                            sudo dnf versionlock add salt-syndic
+                            sudo dnf versionlock add salt-cloud
+                            sudo dnf versionlock add salt-api
 
-                Salt Project recommends deploying LTS releases for Production environments.
+               .. tab-item:: 3007 STS
 
-            If users would like to restrict their installs to the Salt 3007 STS point releases,
-            these install steps include enabling Salt 3007 STS release downloads.
+                    .. warning:: STS not recommended for Production
 
-            .. code-block:: bash
+                        Salt Project recommends deploying LTS releases for Production environments.
 
-                    # Enable the Salt 3007 STS repo
-                    sudo dnf config-manager --set-disable salt-repo-*
-                    sudo dnf config-manager --set-enabled salt-repo-3007-sts
+                    If users would like to restrict their installs to the Salt 3007 STS point releases,
+                    these install steps include enabling Salt 3007 STS release downloads.
 
-            Available installs:
+                    .. code-block:: bash
 
-            .. code-block:: bash
+                            # Enable the Salt 3007 STS repo
+                            sudo dnf config-manager --set-disable salt-repo-*
+                            sudo dnf config-manager --set-enabled salt-repo-3007-sts
 
-                    sudo dnf install salt-master
-                    sudo dnf install salt-minion
-                    sudo dnf install salt-ssh
-                    sudo dnf install salt-syndic
-                    sudo dnf install salt-cloud
-                    sudo dnf install salt-api
+                    Available installs:
 
-            If wanting to install by a target point release, append the specific Salt
-            full release version. For example:
+                    .. code-block:: bash
 
-            .. code-block:: bash
+                            sudo dnf install salt-master
+                            sudo dnf install salt-minion
+                            sudo dnf install salt-ssh
+                            sudo dnf install salt-syndic
+                            sudo dnf install salt-cloud
+                            sudo dnf install salt-api
 
-                    sudo dnf install salt-master-3007.1
-                    sudo dnf install salt-minion-3007.1
-                    sudo dnf install salt-ssh-3007.1
-                    sudo dnf install salt-syndic-3007.1
-                    sudo dnf install salt-cloud-3007.1
-                    sudo dnf install salt-api-3007.1
+                    If wanting to install by a target point release, append the specific Salt
+                    full release version. For example:
 
-            ``dnf versionlock`` can be used to pin to minor versions, if wanting to be
-            excluded during ``dnf upgrade`` runs on a system.
+                    .. code-block:: bash
 
-            .. code-block:: bash
+                            sudo dnf install salt-master-3007.1
+                            sudo dnf install salt-minion-3007.1
+                            sudo dnf install salt-ssh-3007.1
+                            sudo dnf install salt-syndic-3007.1
+                            sudo dnf install salt-cloud-3007.1
+                            sudo dnf install salt-api-3007.1
 
-                    sudo dnf install 'dnf-command(versionlock)'
+                    ``dnf versionlock`` can be used to pin to minor versions, if wanting to be
+                    excluded during ``dnf upgrade`` runs on a system.
 
-            .. code-block:: bash
+                    .. code-block:: bash
 
-                    sudo dnf versionlock add salt
-                    sudo dnf versionlock add salt-master
-                    sudo dnf versionlock add salt-minion
-                    sudo dnf versionlock add salt-ssh
-                    sudo dnf versionlock add salt-syndic
-                    sudo dnf versionlock add salt-cloud
-                    sudo dnf versionlock add salt-api
+                            sudo dnf install 'dnf-command(versionlock)'
 
-       .. tab-item:: LATEST Available
+                    .. code-block:: bash
 
-            .. warning:: STS not recommended for Production
+                            sudo dnf versionlock add salt
+                            sudo dnf versionlock add salt-master
+                            sudo dnf versionlock add salt-minion
+                            sudo dnf versionlock add salt-ssh
+                            sudo dnf versionlock add salt-syndic
+                            sudo dnf versionlock add salt-cloud
+                            sudo dnf versionlock add salt-api
 
-                Salt Project recommends deploying LTS releases for Production environments.
+               .. tab-item:: LATEST Available
 
-            If users would like to leave installs to come from either LTS or STS, whichever
-            major version is latest.
+                    .. warning:: STS not recommended for Production
 
-            .. code-block:: bash
+                        Salt Project recommends deploying LTS releases for Production environments.
 
-                    # Enable the Salt LATEST repo
-                    sudo dnf config-manager --set-disable salt-repo-*
-                    sudo dnf config-manager --set-enabled salt-repo-latest
+                    If users would like to leave installs to come from either LTS or STS, whichever
+                    major version is latest.
 
-            Available installs:
+                    .. code-block:: bash
 
-            .. code-block:: bash
+                            # Enable the Salt LATEST repo
+                            sudo dnf config-manager --set-disable salt-repo-*
+                            sudo dnf config-manager --set-enabled salt-repo-latest
 
-                    sudo dnf install salt-master
-                    sudo dnf install salt-minion
-                    sudo dnf install salt-ssh
-                    sudo dnf install salt-syndic
-                    sudo dnf install salt-cloud
-                    sudo dnf install salt-api
+                    Available installs:
 
-            If wanting to install by a target point release, append the specific Salt
-            full release version. For example:
+                    .. code-block:: bash
 
-            .. code-block:: bash
+                            sudo dnf install salt-master
+                            sudo dnf install salt-minion
+                            sudo dnf install salt-ssh
+                            sudo dnf install salt-syndic
+                            sudo dnf install salt-cloud
+                            sudo dnf install salt-api
 
-                    sudo dnf install salt-master-3007.1
-                    sudo dnf install salt-minion-3007.1
-                    sudo dnf install salt-ssh-3007.1
-                    sudo dnf install salt-syndic-3007.1
-                    sudo dnf install salt-cloud-3007.1
-                    sudo dnf install salt-api-3007.1
+                    If wanting to install by a target point release, append the specific Salt
+                    full release version. For example:
 
-            ``dnf versionlock`` can be used to pin to minor versions, if wanting to be
-            excluded during ``dnf upgrade`` runs on a system.
+                    .. code-block:: bash
 
-            .. code-block:: bash
+                            sudo dnf install salt-master-3007.1
+                            sudo dnf install salt-minion-3007.1
+                            sudo dnf install salt-ssh-3007.1
+                            sudo dnf install salt-syndic-3007.1
+                            sudo dnf install salt-cloud-3007.1
+                            sudo dnf install salt-api-3007.1
 
-                    sudo dnf install 'dnf-command(versionlock)'
+                    ``dnf versionlock`` can be used to pin to minor versions, if wanting to be
+                    excluded during ``dnf upgrade`` runs on a system.
 
-            .. code-block:: bash
+                    .. code-block:: bash
 
-                    sudo dnf versionlock add salt
-                    sudo dnf versionlock add salt-master
-                    sudo dnf versionlock add salt-minion
-                    sudo dnf versionlock add salt-ssh
-                    sudo dnf versionlock add salt-syndic
-                    sudo dnf versionlock add salt-cloud
-                    sudo dnf versionlock add salt-api
+                            sudo dnf install 'dnf-command(versionlock)'
+
+                    .. code-block:: bash
+
+                            sudo dnf versionlock add salt
+                            sudo dnf versionlock add salt-master
+                            sudo dnf versionlock add salt-minion
+                            sudo dnf versionlock add salt-ssh
+                            sudo dnf versionlock add salt-syndic
+                            sudo dnf versionlock add salt-cloud
+                            sudo dnf versionlock add salt-api
+
+       .. tab-item:: Zypper
+
+           .. tab-set::
+
+               .. tab-item:: 3006 LTS
+
+                    .. warning:: Latest will be installed without locking the package version to the 3006 major version
+
+                        The following commands can be used to lock the major version
+
+                        .. code-block:: bash
+
+                                sudo zypper addlock "salt-minion < 3006" && sudo zypper addlock "salt-minion >= 3007"
+                                sudo zypper addlock "salt-master < 3006" && sudo zypper addlock "salt-master >= 3007"
+                                sudo zypper addlock "salt-ssh < 3006" && sudo zypper addlock "salt-ssh >= 3007"
+                                sudo zypper addlock "salt-syndic < 3006" && sudo zypper addlock "salt-syndic >= 3007"
+                                sudo zypper addlock "salt-cloud < 3006" && sudo zypper addlock "salt-cloud >= 3007"
+                                sudo zypper addlock "salt-api < 3006" && sudo zypper addlock "salt-api >= 3007"
+
+                    Available installs:
+
+                    .. code-block:: bash
+
+                            sudo zypper install salt-master
+                            sudo zypper install salt-minion
+                            sudo zypper install salt-ssh
+                            sudo zypper install salt-syndic
+                            sudo zypper install salt-cloud
+                            sudo zypper install salt-api
+
+                    If wanting to install by a target point release, append the specific Salt
+                    full release version. For example:
+
+                    .. code-block:: bash
+
+                            sudo zypper install salt-master-3006.9
+                            sudo zypper install salt-minion-3006.9
+                            sudo zypper install salt-ssh-3006.9
+                            sudo zypper install salt-syndic-3006.9
+                            sudo zypper install salt-cloud-3006.9
+                            sudo zypper install salt-api-3006.9
+
+                    ``zypper addlock`` can be used to pin to minor versions, if wanting to be
+                    excluded during ``zypper update`` runs on a system.
+
+                    .. code-block:: bash
+
+                            sudo zypper addlock salt
+                            sudo zypper addlock salt-master
+                            sudo zypper addlock salt-minion
+                            sudo zypper addlock salt-ssh
+                            sudo zypper addlock add salt-syndic
+                            sudo zypper addlock add salt-cloud
+                            sudo zypper addlock add salt-api
+
+               .. tab-item:: 3007 STS
+
+                    .. warning:: STS not recommended for Production
+
+                        Salt Project recommends deploying LTS releases for Production environments.
+
+                    .. warning:: Latest will be installed without locking the package version to the 3007 major version
+
+                        The following commands can be used to lock the major version
+
+                        .. code-block:: bash
+
+                                sudo zypper addlock "salt-minion < 3007" && sudo zypper addlock "salt-minion >= 3008"
+                                sudo zypper addlock "salt-master < 3007" && sudo zypper addlock "salt-master >= 3008"
+                                sudo zypper addlock "salt-ssh < 3007" && sudo zypper addlock "salt-ssh >= 3008"
+                                sudo zypper addlock "salt-syndic < 3007" && sudo zypper addlock "salt-syndic >= 3008"
+                                sudo zypper addlock "salt-cloud < 3007" && sudo zypper addlock "salt-cloud >= 3008"
+                                sudo zypper addlock "salt-api < 3007" && sudo zypper addlock "salt-api >= 3008"
+
+                        Salt Project recommends deploying LTS releases for Production environments.
+
+                    Available installs:
+
+                    .. code-block:: bash
+
+                            sudo zypper install salt-master
+                            sudo zypper install salt-minion
+                            sudo zypper install salt-ssh
+                            sudo zypper install salt-syndic
+                            sudo zypper install salt-cloud
+                            sudo zypper install salt-api
+
+                    If wanting to install by a target point release, append the specific Salt
+                    full release version. For example:
+
+                    .. code-block:: bash
+
+                            sudo zypper install salt-master-3007.1
+                            sudo zypper install salt-minion-3007.1
+                            sudo zypper install salt-ssh-3007.1
+                            sudo zypper install salt-syndic-3007.1
+                            sudo zypper install salt-cloud-3007.1
+                            sudo zypper install salt-api-3007.1
+
+                    ``zypper addlock`` can be used to pin to minor versions, if wanting to be
+                    excluded during ``zypper update`` runs on a system.
+
+                    .. code-block:: bash
+
+                            sudo zypper addlock salt
+                            sudo zypper addlock salt-master
+                            sudo zypper addlock salt-minion
+                            sudo zypper addlock salt-ssh
+                            sudo zypper addlock add salt-syndic
+                            sudo zypper addlock add salt-cloud
+                            sudo zypper addlock add salt-api
+
+               .. tab-item:: LATEST Available
+
+                    .. warning:: STS not recommended for Production
+
+                        Salt Project recommends deploying LTS releases for Production environments.
+
+                    Available installs:
+
+                    .. code-block:: bash
+
+                            sudo zypper install salt-master
+                            sudo zypper install salt-minion
+                            sudo zypper install salt-ssh
+                            sudo zypper install salt-syndic
+                            sudo zypper install salt-cloud
+                            sudo zypper install salt-api
+
+                    If wanting to install by a target point release, append the specific Salt
+                    full release version. For example:
+
+                    .. code-block:: bash
+
+                            sudo zypper install salt-master-3007.1
+                            sudo zypper install salt-minion-3007.1
+                            sudo zypper install salt-ssh-3007.1
+                            sudo zypper install salt-syndic-3007.1
+                            sudo zypper install salt-cloud-3007.1
+                            sudo zypper install salt-api-3007.1
+
+                    ``zypper addlock`` can be used to pin to minor versions, if wanting to be
+                    excluded during ``zypper update`` runs on a system.
+
+                    .. code-block:: bash
+
+                            sudo zypper addlock salt
+                            sudo zypper addlock salt-master
+                            sudo zypper addlock salt-minion
+                            sudo zypper addlock salt-ssh
+                            sudo zypper addlock add salt-syndic
+                            sudo zypper addlock add salt-cloud
+                            sudo zypper addlock add salt-api
+
+
 
 #. Enable and start the Salt services:
 

--- a/salt-zypper.repo
+++ b/salt-zypper.repo
@@ -1,0 +1,9 @@
+[salt-repo-latest]
+name=Salt Repo for Salt LATEST release
+baseurl=https://packages.broadcom.com/artifactory/saltproject-rpm/
+skip_if_unavailable=True
+priority=10
+enabled=1
+enabled_metadata=1
+gpgcheck=1
+gpgkey=https://packages.broadcom.com/artifactory/api/security/keypair/SaltProjectKey/public


### PR DESCRIPTION
The current instructions only support installing from the broadcom repositories with DNF. This adds instructions for how to use the broadcom repositories with Zypper on SUSE based operating systems. 

One notable difference between DNF and Zypper is that Zypper's .repo format does not allow for excluding specific packages. This means there will only be one repo for all versions and instructions are given for how to use zyppers locking functionality to pin to a major version. A salt-zypper.repo file was added to better support the locking instructions with major version pinning.