### PR TITLE
GHA deploy job fixes: Download artifacts properly for uploading release artifacts on tag

### DIFF
--- a/.github/workflows/build-sphinx-docs.yml
+++ b/.github/workflows/build-sphinx-docs.yml
@@ -52,18 +52,15 @@ jobs:
   deploy:
     permissions:
       contents: write
-    environment:
-      name: release
-      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs:
       - build
-    if: success() && github.ref == 'refs/heads/main'
+    if: success() && startsWith(github.ref, 'refs/tags/')
     steps:
-      - name: Download artifacts
-        uses: actions/download-artifact@v4
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
       - name: Display all downloaded archives/artifacts
         run: |
           ls -lah
@@ -78,11 +75,10 @@ jobs:
 
           echo "
           Creating checksums.txt..."
-          sha512sum salt-install-guide.tar.gz salt.repo salt.sources > tee checksums.txt
+          sha512sum salt-install-guide.tar.gz salt.repo salt.sources | tee checksums.txt
 
       - name: Release
         uses: softprops/action-gh-release@v2
-        if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
             checksums.txt


### PR DESCRIPTION
GHA updates:
- Remove `release` env
- Checkout git prior to artifact download, otherwise lose download
- Pipe to `tee`
- Ensure if conditional runs only on tag for `deploy` job