### PR TITLE
Add note about SUSE and Photon OS

### DIFF
--- a/docs/topics/install-by-operating-system/linux-rpm.rst
+++ b/docs/topics/install-by-operating-system/linux-rpm.rst
@@ -7,6 +7,16 @@ Linux (RPM)
 These instructions explain how to install Salt rpms on operating systems that
 are RHEL-like (using ``dnf`` install methods).
 
+.. Note::
+    Salt packages for SUSE and Photon OS are provided via their own OS package repositories.
+    SUSE and Photon OS create their own Salt packages that aren't ``onedir`` (``relenv``) based, and are
+    patched to be further integrated with their respective operating systems.
+
+    Salt Project **does not** provide custom directions for working with ``zypper``, ``tdnf``, or other
+    non-DNF package managers to install packages from the Salt Project RPM repository.
+
+    RPM packages, hosted by Salt Project, are still tested on SUSE and Photon OS operating systems via our CI/CD.
+
 For a list of supported and tested operating systems, for running Salt,
 see :ref:`salt-supported-operating-systems`.
 


### PR DESCRIPTION
- The previous Salt Install Guide, prior to migrations, directed users to make use of the SUSE-provide packages of Salt. This restores that, along with an included note about Photon OS
- Though our `onedir` (`relenv`) packages are tested in CI/CD on Photon OS and openSUSE, Salt Project will not be providing directions for additional package managers outside of `dnf` for RPM-based installs
  - In the meantime, there is a related issue opened for expanding `tdnf` to support glob lists in `excludepkgs` (and potentially `exclude` as an alias to `excludepkgs`): https://github.com/vmware/tdnf/issues/505
- This PR also supersedes #14 