### PR TITLE
Correct double slash in URL for salt-install-guide

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -65,4 +65,4 @@ Install Salt
    Open a Salt issue to report bugs <https://github.com/saltstack/salt/issues/new/choose>
    Open an Install Guide docs issue <https://github.com/saltstack/salt-install-guide/issues/new>
    Salt docs contributing guide <https://saltstack.gitlab.io/open/docs/docs-hub/topics/contributing.html>
-   Salt Install Guide source <https://github.com/saltstack//salt-install-guide>
+   Salt Install Guide source <https://github.com/saltstack/salt-install-guide>


### PR DESCRIPTION
Correct double slash in URL for salt-install-guide

Fixes https://github.com/saltstack/salt-install-guide/issues/24
