### PR TITLE
Bumping support windows from April to June

### DIFF
--- a/docs/topics/salt-version-support-lifecycle.rst
+++ b/docs/topics/salt-version-support-lifecycle.rst
@@ -26,13 +26,13 @@ Version support lifecycle
 
   * - 3007 STS
     - March 6, 2024
-    - April, 2025
-    - April, 2025
+    - June, 2025
+    - June, 2025
 
   * - 3006 LTS
     - April 18, 2023
-    - April, 2025
-    - April, 2026
+    - June, 2025
+    - June, 2026
 
 .. Note::
     Salt Project is committed to providing active support for the current LTS


### PR DESCRIPTION
Bumping support windows for Salt v3006 LTS and Salt v3007 STS out a few more months, in order to further develop and test Salt v3008 LTS before that major version GA release.