### PR TITLE
Adding the Sphinx sitemap extension

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -116,6 +116,7 @@ extensions = [
     "sphinx-prompt",  # Required by sphinx_substitution_extensions
     "sphinx_inline_tabs",
     "sphinx_substitution_extensions",
+    "sphinx-sitemap",
 ]
 # Render TODO directives
 todo_include_todos = True
@@ -149,6 +150,7 @@ exclude_patterns = [
 html_show_sourcelink = True  # False on private repos; True on public repos
 html_theme = "furo"
 html_title = "Salt install guide"
+html_baseurl = "https://docs.saltproject.io/salt/install-guide/en/latest/"
 
 html_theme_options = {
     "dark_css_variables": {

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,3 +6,5 @@ sphinx-prompt>=1.5.0
 sphinx-substitution-extensions>=2022.02.16
 sphinx-tabs>=3.4.7
 sphinx>=5.3.0
+sphinx-sitemap==2.6.0
+


### PR DESCRIPTION
I successfully created a local version on my laptop. I then updated the `conf.py` with the extension name and the `baseurl` and then updated the requirements.txt file with the name of the extension.

I got an error 
` File "C:\Users\USER\Desktop\Open Source\salt-install-guide\.nox\docs-html-gen_sitevars-true-clean-true\Lib\site-packages\sphinx\registry.py", line 544, in load_extension
        raise ExtensionError(
            __('Could not import extension %s') % extname, err
        ) from err
    sphinx.errors.ExtensionError: Could not import extension sphinx-sitemap (exception: No module named 'sphinx-sitemap')`

I am sure I did everything well.