### PR TITLE
Updating to bump latest operating systems

### DIFF
--- a/docs/topics/salt-supported-operating-systems.rst
+++ b/docs/topics/salt-supported-operating-systems.rst
@@ -43,6 +43,13 @@ Overview of supported operating systems
     - Full
     -
 
+  * - `AlmaLinux`_ 10
+    - x86_64, aarch64 / arm64
+    - Yes
+    - Yes
+    - Full
+    -
+
   * - `Amazon Linux`_ 2
     - x86_64, aarch64 / arm64
     -
@@ -85,14 +92,21 @@ Overview of supported operating systems
     - Full
     - Yes
 
-  * - `macOS`_ 12
-    - x86_64
+  * - `macOS`_ 13
+    - x86_64, arm64
     -
     - Yes
     - Full
     -
 
-  * - `macOS`_ 13
+  * - `macOS`_ 14
+    - x86_64, arm64
+    -
+    - Yes
+    - Full
+    -
+
+  * - `macOS`_ 15
     - x86_64, arm64
     -
     - Yes
@@ -141,6 +155,13 @@ Overview of supported operating systems
     - Full
     -
 
+  * - `RedHat`_ 10
+    - x86_64, aarch64 / arm64
+    - Yes
+    - Yes
+    - Full
+    -
+
   * - `Rocky Linux`_ 8
     - x86_64, aarch64 / arm64
     - Yes
@@ -155,6 +176,13 @@ Overview of supported operating systems
     - Full
     - Yes
 
+  * - `Rocky Linux`_ 10
+    - x86_64, aarch64 / arm64
+    - Yes
+    - Yes
+    - Full
+    -
+
   * - `SLES`_ 12 SP5
     -
     - Yes
@@ -168,13 +196,6 @@ Overview of supported operating systems
     - Yes
     - Full
     -
-
-  * - `Ubuntu`_ 20.04
-    - amd64, arm64
-    - Yes
-    - Yes
-    - Full
-    - Yes
 
   * - `Ubuntu`_ 22.04
     - amd64, arm64
@@ -209,16 +230,23 @@ Overview of supported operating systems
     -
     - Yes
     - Full
-    - Yes
+    -
 
   * - `Windows`_ 2019
     - x86, AMD64
     -
     - Yes
     - Full
-    - Yes
+    -
 
   * - `Windows`_ 2022
+    - x86, AMD64
+    -
+    - Yes
+    - Full
+    - Yes
+
+  * - `Windows`_ 2025
     - x86, AMD64
     -
     - Yes


### PR DESCRIPTION
## What does this PR do?

Updating to reflect latest support on select operating systems.

- Add Rocky Linux / RHEL / AlmaLinux 10 support (but not in test suite yet)
- Add MacOS 14 and MacOS 15 support (included in test suite)
- Add Windows 2025 support (included in test suite)
- Dropping MacOS 12 and Ubuntu 20.04 as no longer officially supported (due to EOL operating systems)