### PR TITLE
Update install guide for Salt 3008.0 LTS release

### DIFF
--- a/docs/topics/_includes/macos-downloads.rst
+++ b/docs/topics/_includes/macos-downloads.rst
@@ -31,9 +31,9 @@
     - Download install file
 
   * - x86_64
-    - sts
+    - lts
     - |macos-amd64-two-download|
 
   * - arm64
-    - sts
+    - lts
     - |macos-arm64-two-download|

--- a/docs/topics/_includes/windows-downloads.rst
+++ b/docs/topics/_includes/windows-downloads.rst
@@ -46,20 +46,20 @@
 
   * - AMD64
     - exe
-    - STS
+    - LTS
     - |windows-amd64-exe-two-download|
 
   * - AMD64
     - msi
-    - STS
+    - LTS
     - |windows-amd64-msi-two-download|
 
   * - x86
     - exe
-    - STS
+    - LTS
     - |windows-x86-exe-two-download|
 
   * - x86
     - msi
-    - STS
+    - LTS
     - |windows-x86-msi-two-download|

--- a/docs/topics/announcements.rst
+++ b/docs/topics/announcements.rst
@@ -29,6 +29,35 @@ for the latest announcements.
 Release announcements
 =====================
 
+* **May 27, 2026:** `3008.0 <https://docs.saltproject.io/en/3008/topics/releases/3008.0.html>`_ is now available.
+* **May 13, 2026:** `3006.25 <https://docs.saltproject.io/en/3006/topics/releases/3006.25.html>`_ is now available.
+* **April 29, 2026:** `3007.14 <https://docs.saltproject.io/en/3007/topics/releases/3007.14.html>`_ is now available.
+* **April 23, 2026:** `3006.24 <https://docs.saltproject.io/en/3006/topics/releases/3006.24.html>`_ is now available.
+* **February 23, 2026:** `3006.23 <https://docs.saltproject.io/en/3006/topics/releases/3006.23.html>`_ is now available.
+* **February 21, 2026:** `3006.22 <https://docs.saltproject.io/en/3006/topics/releases/3006.22.html>`_ is now available.
+* **February 11, 2026:** `3007.13 <https://docs.saltproject.io/en/3007/topics/releases/3007.13.html>`_ is now available.
+* **February 11, 2026:** `3006.21 <https://docs.saltproject.io/en/3006/topics/releases/3006.21.html>`_ is now available.
+* **February 5, 2026:** `3007.12 <https://docs.saltproject.io/en/3007/topics/releases/3007.12.html>`_ is now available.
+* **February 5, 2026:** `3006.20 <https://docs.saltproject.io/en/3006/topics/releases/3006.20.html>`_ is now available.
+* **January 9, 2026:** `3007.11 <https://docs.saltproject.io/en/3007/topics/releases/3007.11.html>`_ is now available.
+* **January 9, 2026:** `3006.19 <https://docs.saltproject.io/en/3006/topics/releases/3006.19.html>`_ is now available.
+* **December 18, 2025:** `3007.10 <https://docs.saltproject.io/en/3007/topics/releases/3007.10.html>`_ is now available.
+* **December 18, 2025:** `3006.18 <https://docs.saltproject.io/en/3006/topics/releases/3006.18.html>`_ is now available.
+* **November 20, 2025:** `3007.9 <https://docs.saltproject.io/en/3007/topics/releases/3007.9.html>`_ is now available.
+* **November 20, 2025:** `3006.17 <https://docs.saltproject.io/en/3006/topics/releases/3006.17.html>`_ is now available.
+* **September 18, 2025:** `3007.8 <https://docs.saltproject.io/en/3007/topics/releases/3007.8.html>`_ is now available.
+* **September 17, 2025:** `3006.16 <https://docs.saltproject.io/en/3006/topics/releases/3006.16.html>`_ is now available.
+* **August 28, 2025:** `3007.7 <https://docs.saltproject.io/en/3007/topics/releases/3007.7.html>`_ is now available.
+* **August 28, 2025:** `3006.15 <https://docs.saltproject.io/en/3006/topics/releases/3006.15.html>`_ is now available.
+* **July 10, 2025:** `3007.6 <https://docs.saltproject.io/en/3007/topics/releases/3007.6.html>`_ is now available.
+* **July 10, 2025:** `3006.14 <https://docs.saltproject.io/en/3006/topics/releases/3006.14.html>`_ is now available.
+* **June 26, 2025:** `3007.5 <https://docs.saltproject.io/en/3007/topics/releases/3007.5.html>`_ is now available.
+* **June 26, 2025:** `3006.13 <https://docs.saltproject.io/en/3006/topics/releases/3006.13.html>`_ is now available.
+* **June 12, 2025:** `3007.4 <https://docs.saltproject.io/en/3007/topics/releases/3007.4.html>`_ is now available.
+* **June 12, 2025:** `3006.12 <https://docs.saltproject.io/en/3006/topics/releases/3006.12.html>`_ is now available.
+* **June 4, 2025:** `3007.3 <https://docs.saltproject.io/en/3007/topics/releases/3007.3.html>`_ is now available.
+* **June 2, 2025:** `3006.11 <https://docs.saltproject.io/en/3006/topics/releases/3006.11.html>`_ is now available.
+* **May 13, 2025:** `3007.2 <https://docs.saltproject.io/en/3007/topics/releases/3007.2.html>`_ is now available.
 * **March 19, 2025:** `3006.10 <https://docs.saltproject.io/en/3006/topics/releases/3006.10.html>`_ is now available.
 * **July 30, 2024:** `3006.9 <https://docs.saltproject.io/en/3006/topics/releases/3006.9.html>`_ is now available.
 * **May 22, 2024:** `3007.1 <https://docs.saltproject.io/en/3007/topics/releases/3007.1.html>`_ is now available.

--- a/docs/topics/salt-version-support-lifecycle.rst
+++ b/docs/topics/salt-version-support-lifecycle.rst
@@ -24,15 +24,20 @@ Version support lifecycle
     - `Active support`_ ends
     - `CVE and critical support`_ ends
 
+  * - 3008 LTS
+    - May 27, 2026
+    - June, 2027
+    - June, 2028
+
   * - 3007 STS
     - March 6, 2024
-    - July, 2026
-    - July, 2026
+    - June, 2026
+    - —
 
   * - 3006 LTS
     - April 18, 2023
-    - July, 2026
-    - July, 2027
+    - June, 2027
+    - June, 2028
 
 .. Note::
     Salt Project is committed to providing active support for the current LTS

--- a/salt.repo
+++ b/salt.repo
@@ -3,21 +3,21 @@ name=Salt Repo for Salt v3006 LTS
 baseurl=https://packages.broadcom.com/artifactory/saltproject-rpm/
 skip_if_unavailable=True
 priority=10
-enabled=1
+enabled=0
 enabled_metadata=1
 gpgcheck=1
 exclude=*3007* *3008* *3009* *3010*
 gpgkey=https://packages.broadcom.com/artifactory/api/security/keypair/SaltProjectKey/public
 
-[salt-repo-3007-sts]
-name=Salt Repo for Salt v3007 STS
+[salt-repo-3008-lts]
+name=Salt Repo for Salt v3008 LTS
 baseurl=https://packages.broadcom.com/artifactory/saltproject-rpm/
 skip_if_unavailable=True
 priority=10
-enabled=0
+enabled=1
 enabled_metadata=1
 gpgcheck=1
-exclude=*3006* *3008* *3009* *3010*
+exclude=*3006* *3007* *3009* *3010*
 gpgkey=https://packages.broadcom.com/artifactory/api/security/keypair/SaltProjectKey/public
 
 [salt-repo-latest]


### PR DESCRIPTION
## What does this PR do?
- Replace salt-repo-3007-sts with salt-repo-3008-lts in salt.repo; set 3008-lts as the default enabled repo and 3006-lts as opt-in
- Update version support lifecycle table: add 3008 LTS row, mark 3007 STS active support ended June 2026 with no CVE/critical support, extend 3006 LTS end dates; order table highest to lowest version
- Fix hardcoded STS release type labels to LTS in macOS and Windows download tables (both supported versions are now LTS)
- Add 3008.0 release announcement and backfill all missing 3006.x (3006.11–3006.25) and 3007.x (3007.2–3007.14) release announcements

## What issues does this PR fix or reference?
Fixes #71

## Merge requirements satisfied? (FOR REVIEWER USE ONLY)

- [ ] Verify the pipeline is passing
- [ ] Check rendered output to ensure formatting is correct for any special
      directives such as notes, tables, lists, and images
