### PR TITLE
Fix release.yml: set GH_REPO so lookup step works before checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,11 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
+    env:
+      # gh CLI needs repo context for `pr list/merge/checks/create`. Setting
+      # GH_REPO at job level means those calls work before checkout (the
+      # lookup step runs before any checkout).
+      GH_REPO: ${{ github.repository }}
     steps:
       - name: Detect target salt version
         id: detect


### PR DESCRIPTION
Fixes the failure observed in the first scheduled run after merge:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
##[error]Process completed with exit code 1.
```

The `Look up existing PR for this version` step runs before any checkout, so `gh pr list --head <branch>` had no git context and could not infer the repo. Setting `GH_REPO: ${{ github.repository }}` at job level resolves the repo from env for all `gh pr`/`gh run` calls, regardless of whether `.git` is on disk yet.

One-line change, no behavioural difference once running.