### PR TITLE
docs: use rclone --checksum for air-gap repo mirroring

### DIFF
--- a/docs/topics/other-install-types/air-gap-install.rst
+++ b/docs/topics/other-install-types/air-gap-install.rst
@@ -20,6 +20,20 @@ Create a local mirror with ``rclone`` (faster)
 
       Only sync once per day.
 
+.. important::
+
+      Always pass the ``-c`` / ``--checksum`` flag to ``rclone sync``. Without
+      it, ``rclone`` compares files by size and modification time only. The
+      Salt package repositories publish updates in which small companion
+      files (``*.md5``, ``*.sha1``, ``*.sha256``, ``Release``,
+      ``Release.gpg``, ``InRelease``, and the RPM ``repodata/repomd.xml``) can
+      keep the same size while their content changes, so a size+mtime
+      comparison silently skips them. The stale hash/metadata files then
+      cause ``apt`` (and ``yum``/``dnf``) to reject the mirror with
+      "unexpected size" / hash-mismatch errors. See
+      `issue 69652 <https://github.com/saltstack/salt/issues/69652>`__ for
+      the original report.
+
 To set up local mirrors with ``rclone``:
 
 .. tab-set::
@@ -28,52 +42,31 @@ To set up local mirrors with ``rclone``:
 
          Syncs down the following repo: `saltproject-rpm <https://packages.broadcom.com/artifactory/saltproject-rpm/>`__
 
-         #. In the ``rclone`` command line, adapt this example:
+         In the ``rclone`` command line, adapt this example:
 
-            .. code-block:: bash
+         .. code-block:: bash
 
-                  RCLONE_WEBDAV_URL=https://packages.broadcom.com/artifactory/ RCLONE_WEBDAV_VENDOR=other rclone sync --fast-list --use-server-modtime -v :webdav:saltproject-rpm/ ./saltproject-rpm/
-
-         #. (Optional): If you can't use the ``--use-server-modtime`` flag because your
-            version of ``rclone`` is too old, you can use the ``-c flag`` instead:
-
-            .. code-block:: bash
-
-                  RCLONE_WEBDAV_URL=https://packages.broadcom.com/artifactory/ RCLONE_WEBDAV_VENDOR=other rclone sync --fast-list -c -v :webdav:saltproject-rpm/ ./saltproject-rpm/
+               RCLONE_WEBDAV_URL=https://packages.broadcom.com/artifactory/ RCLONE_WEBDAV_VENDOR=other rclone sync --fast-list --checksum -v :webdav:saltproject-rpm/ ./saltproject-rpm/
 
       .. tab-item:: Linux (DEB)
 
          Syncs down the following repo: `saltproject-deb <https://packages.broadcom.com/artifactory/saltproject-deb/>`__
 
-         #. In the ``rclone`` command line, adapt this example:
+         In the ``rclone`` command line, adapt this example:
 
-            .. code-block:: bash
+         .. code-block:: bash
 
-                  RCLONE_WEBDAV_URL=https://packages.broadcom.com/artifactory/ RCLONE_WEBDAV_VENDOR=other rclone sync --fast-list --use-server-modtime -v :webdav:saltproject-deb/ ./saltproject-deb/
-
-         #. (Optional): If you can't use the ``--use-server-modtime`` flag because your
-            version of ``rclone`` is too old, you can use the ``-c flag`` instead:
-
-            .. code-block:: bash
-
-                  RCLONE_WEBDAV_URL=https://packages.broadcom.com/artifactory/ RCLONE_WEBDAV_VENDOR=other rclone sync --fast-list -c -v :webdav:saltproject-deb/ ./saltproject-deb/
+               RCLONE_WEBDAV_URL=https://packages.broadcom.com/artifactory/ RCLONE_WEBDAV_VENDOR=other rclone sync --fast-list --checksum -v :webdav:saltproject-deb/ ./saltproject-deb/
 
       .. tab-item:: Generic (Windows, macOS, etc.)
 
          Syncs down the following repo: `saltproject-generic <https://packages.broadcom.com/artifactory/saltproject-generic/>`__
 
-         #. In the ``rclone`` command line, adapt this example:
+         In the ``rclone`` command line, adapt this example:
 
-            .. code-block:: bash
+         .. code-block:: bash
 
-                  RCLONE_WEBDAV_URL=https://packages.broadcom.com/artifactory/ RCLONE_WEBDAV_VENDOR=other rclone sync --fast-list --use-server-modtime -v :webdav:saltproject-generic/ ./saltproject-generic/
-
-         #. (Optional): If you can't use the ``--use-server-modtime`` flag because your
-            version of ``rclone`` is too old, you can use the ``-c flag`` instead:
-
-            .. code-block:: bash
-
-                  RCLONE_WEBDAV_URL=https://packages.broadcom.com/artifactory/ RCLONE_WEBDAV_VENDOR=other rclone sync --fast-list -c -v :webdav:saltproject-generic/ ./saltproject-generic/
+               RCLONE_WEBDAV_URL=https://packages.broadcom.com/artifactory/ RCLONE_WEBDAV_VENDOR=other rclone sync --fast-list --checksum -v :webdav:saltproject-generic/ ./saltproject-generic/
 
 
 Create a local mirror with ``wget`` (slower)


### PR DESCRIPTION
## Summary

Fixes saltstack/salt#69652.

The current air-gap install instructions recommend
`rclone sync --fast-list --use-server-modtime ...` (with `-c` shown
only as a fallback for old rclone versions). This is wrong: `rclone`
then compares files using size and modification time only.

The Salt package repositories on Broadcom Artifactory publish updates
where the small metadata companion files -- `*.md5`, `*.sha1`,
`*.sha256`, `Release`, `Release.gpg`, `InRelease`, and the RPM
`repodata/repomd.xml` -- keep the same size while their content
changes, and whose server-side mtime does not always advance in
lock-step with the sibling `Packages` / RPM index files. rclone's
default size+mtime comparison silently skips them, so the mirror ends
up with a fresh `Packages` / `Packages.bz2` but stale hash and Release
files. `apt update` then reports:

```
File has unexpected size (161260 != 143530). Mirror sync in progress?
Hashes of expected file: ...
Release file created at: <old date>
```

and clients cannot see new package versions.

The reporter's workaround is to `rm` all the hash/Release files before
every sync. The upstream `rclone` documentation explicitly recommends
`-c` / `--checksum` for exactly this situation:

> Normally rclone will look at modification time and size of files to
> see if they are equal. If you set this flag then rclone will check
> the file hash and size to determine if files are equal.

(<https://rclone.org/docs/#c-checksum>)

## Change

- Replace the primary `rclone sync` example for the RPM, DEB, and
  generic mirrors with `rclone sync --fast-list --checksum -v ...`.
- Drop the "Optional: use -c if your rclone is too old" alternative --
  `-c` is not optional, it is required for correctness.
- Add an `.. important::` admonition explaining why `--checksum` is
  required and calling out the affected files (so the same fix is
  applied by anyone who scripts a mirror from these instructions and
  by future readers debugging apt/yum sync failures on their mirror).

## Test plan

- [x] `pre-commit run --files docs/topics/other-install-types/air-gap-install.rst` passes (rstcheck, blacken-docs, nox all green).
- [x] `nox -e 'docs-html(gen_sitevars=False, clean=True)'` -- Sphinx build succeeds with no warnings.
- [x] Rendered HTML shows `--checksum` in all three code blocks and no lingering `--use-server-modtime`.

## Unverified

- The reporter tested on Debian/Ubuntu (`apt`). The same rclone
  size+mtime skip bug affects `repodata/repomd.xml` on RPM mirrors
  in principle, but I did not reproduce the failure on `dnf`/`yum`
  end-to-end. The doc note calls out both cases for defence in depth.