### PR TITLE
Add unified theme elements from user guide

### DIFF
--- a/docs/_static/css/import-all-salt-docs.css
+++ b/docs/_static/css/import-all-salt-docs.css
@@ -1,1 +1,29 @@
 @import url("https://saltstack.gitlab.io/open/docs/docs-hub/_static/css/all-salt-docs.css");
+
+/* Custom Sidebar Title Styling */
+h3.salt-nav-title {
+    font-size: 1.125rem !important; /* Adjusts size to match saltproject.io */
+    font-weight: 600 !important;    /* Gives it a slightly bold, clean weight */
+    margin-bottom: 1rem;
+    padding-left: 0;
+}
+
+h3.salt-nav-title a {
+    color: #333333 !important;      /* Dark gray text matching the main site */
+    text-decoration: none !important; /* Removes the underline */
+    box-shadow: none !important;    /* Removes any border-bottom shadows applied by the theme */
+}
+
+h3.salt-nav-title a:hover {
+    color: #00e1cc !important;      /* Salt Project's signature teal on hover */
+    text-decoration: none !important;
+}
+
+/* Custom Sidebar Title Styling - Dark Mode Override */
+html[data-theme="dark"] h3.salt-nav-title a {
+    color: #f8f9fa !important;        /* Light text for dark mode visibility */
+}
+
+html[data-theme="dark"] h3.salt-nav-title a:hover {
+    color: #00e1cc !important;        /* Keeps the teal hover in dark mode */
+}

--- a/docs/_templates/globaltoc.html
+++ b/docs/_templates/globaltoc.html
@@ -1,4 +1,6 @@
-<h3><a href="{{ pathto(root_doc)|e }}">{{ project|title }}</a></h3>
+<h3 class="salt-nav-title">
+  <a href="{{ pathto(root_doc)|e }}">{{ project|title }}</a>
+</h3>
 <div id="salt-globaltoc">
 {{ toctree(includehidden=True, collapse=False, maxdepth=2) }}
 </div>

--- a/docs/_templates/header-links.html
+++ b/docs/_templates/header-links.html
@@ -65,6 +65,7 @@
       navbarCenter.innerHTML = "";
 
       const links = [
+        { name: "Home", url: "https://saltproject.io/" },
         { name: "Install Guide", url: "https://docs.saltproject.io/salt/install-guide/en/latest/", active: true },
         { name: "User Guide", url: "https://docs.saltproject.io/salt/user-guide/en/latest/" },
         { name: "Reference Docs", url: "https://docs.saltproject.io/en/latest/contents.html" }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -151,16 +151,35 @@ sitemap_excludes = [
     "genindex.html",
 ]
 
-html_logo = None
+html_logo = "_static/img/SaltProject_altlogo_teal.png"
 html_theme_options = {
     "logo": {
-        "image_light": "_static/img/SaltProject_altlogo_blue.png",
-        "image_dark": "_static/img/SaltProject_altlogo_blue.png",
+        "link": "https://saltproject.io",
     },
     "navbar_start": ["navbar-logo"],
     "navbar_center": ["navbar-nav", "header-links"],
     "navbar_end": ["theme-switcher", "navbar-icon-links"],
     "navigation_depth": 4,
+    "icon_links": [
+        {
+            "name": "GitHub",
+            "url": "https://github.com/saltstack/salt-install-guide",
+            "icon": "fa-brands fa-github",
+            "type": "fontawesome",
+        },
+        {
+            "name": "Discord",
+            "url": "https://discord.gg/J7b7EscrAs",
+            "icon": "fa-brands fa-discord",
+            "type": "fontawesome",
+        },
+        {
+            "name": "RSS Feed",
+            "url": "https://saltproject.io/community/rss-feeds/",
+            "icon": "fa-solid fa-rss",
+            "type": "fontawesome",
+        },
+    ],
 }
 
 html_sidebars = {"**": ["globaltoc.html"]}

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-pydata-sphinx-theme>=0.18.0
+pydata-sphinx-theme==0.20.0
 sphinx-copybutton>=0.5.2
 sphinx-design>=0.5.0
 sphinx-inline-tabs>=2023.4.21


### PR DESCRIPTION
- Update top-nav so there is a "Home" button for main saltproject io website
- Update html logo so that the URL goes to saltproject io website
- Update left-hand TOC top header to be in line with main https://saltproject.io left-hand nav TOC header format
- Add social icons/links

Follow-up to https://github.com/saltstack/salt-user-guide/pull/13