### PR TITLE
Add Debian 13 (Trixie) to supported operating systems

### DIFF
--- a/docs/topics/salt-supported-operating-systems.rst
+++ b/docs/topics/salt-supported-operating-systems.rst
@@ -85,6 +85,13 @@ Overview of supported operating systems
     - Full
     - Yes
 
+  * - `Debian`_ 13
+    - amd64, arm64
+    - Yes
+    - Yes
+    - Full
+    - Yes
+
   * - `Fedora`_ 40
     - x86_64, aarch64 / arm64
     - Yes


### PR DESCRIPTION
## What

Add a row for Debian 13 (Trixie) to the supported operating systems
table in `docs/topics/salt-supported-operating-systems.rst`.

## Why

Debian 13 released 2025-08-09. Salt onedir packages install and run on
it, and it is exercised in the CI matrix
(`cicd/shared-gh-workflows-context.yml` in saltstack/salt, x86_64 and
arm64). The current page lists 11 and 12 only, which is inconsistent
with the already-documented policy of "Debian stable, oldstable, and
oldoldstable".

## Tests

Docs-only. `pre-commit run --files docs/topics/salt-supported-operating-systems.rst`
passes (rstcheck, blacken-docs, nox docs build).

Fixes saltstack/salt#69878